### PR TITLE
Feature/add seller to event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `seller` to `addToCart` event.
 
 ## [0.14.0] - 2020-08-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `seller` to `addToCart` event.
+- `sellerName` to `addToCart` event.
 
 ## [0.14.0] - 2020-08-27
 ### Added

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -82,6 +82,7 @@ const adjustSkuItemForPixelEvent = (skuItem: CartItem) => {
     detailUrl: skuItem.detailUrl,
     imageUrl: skuItem.imageUrl,
     referenceId: skuItem?.referenceId?.[0]?.Value,
+    seller: skuItem.seller
   }
 }
 

--- a/react/AddToCartButton.tsx
+++ b/react/AddToCartButton.tsx
@@ -82,7 +82,8 @@ const adjustSkuItemForPixelEvent = (skuItem: CartItem) => {
     detailUrl: skuItem.detailUrl,
     imageUrl: skuItem.imageUrl,
     referenceId: skuItem?.referenceId?.[0]?.Value,
-    seller: skuItem.seller
+    seller: skuItem.seller,
+    sellerName: skuItem.sellerName
   }
 }
 

--- a/react/modules/catalogItemToCart.ts
+++ b/react/modules/catalogItemToCart.ts
@@ -18,6 +18,7 @@ export interface CartItem {
   productId: string
   quantity: number
   seller: string
+  sellerName: string
   sellingPrice: number
   productRefId: string
   brand: string
@@ -77,6 +78,7 @@ export function mapCatalogItemToCart({
           : '',
       productRefId: product.productReference ?? '',
       seller: selectedSeller.sellerId,
+      sellerName: selectedSeller.sellerName,
       variant: selectedItem.name,
       skuName: selectedItem.name,
       price: selectedSeller.commertialOffer.PriceWithoutDiscount * 100,


### PR DESCRIPTION
#### What problem is this solving?

Seller is a extremely important data for market places.

#### How to test it?

In the workspace below, first click in the buy button and then type the following postal code: 05010-040 (if you type an invalid postalCode you may not be regionalize and you won't be able to add the product to cart). After the window reload, you've been regionalized and then you can click on the buy button and see a log in the console with the seller information added to the eventPixel object.

[Workspace](https://productseller--carrefourbrfood.myvtex.com/bisnaguinha-panco-300g-242012/p)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/59736416/91856510-0b010d80-ec3d-11ea-9b48-05186de10990.png)



